### PR TITLE
Added sound manager

### DIFF
--- a/Localization/LocSource.xaml
+++ b/Localization/LocSource.xaml
@@ -35,5 +35,15 @@
     <sys:String x:Key="LOC_PLAYNITESOUNDS_MsgHelp7">Music files need to be mp3 files, depending on the settings be named "_music_.mp3" or have the name of the game with invalid characters removed and be placed in a folder per platform. If you are not exactly sure of the filename and location you can right click on a game and choose the "Show music filename" option. Be Aware, filenames and locations of music files change depending on the settings chosen!</sys:String>
 
     <sys:String x:Key="LOC_PLAYNITESOUNDS_MusicVolume">Music Volume:</sys:String>
+
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_Manager">Sound Manager</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerLoad">Load</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerSave">Save</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerSaveConfirm">Successfully Saved Sound Pack:</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerLoadConfirm">Successfully Loaded Sound Pack:</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerDeleteConfirm">Successfully Deleted Sound Pack:</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerRemove">Remove</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerImport">Import</sys:String>
+  <sys:String x:Key="LOC_PLAYNITESOUNDS_ManagerOpenManagerFolder">Open Sound Manager Folder</sys:String>
     
 </ResourceDictionary>

--- a/PlayniteSounds.cs
+++ b/PlayniteSounds.cs
@@ -689,6 +689,7 @@ namespace PlayniteSounds
                 bool? result = dialog.ShowDialog(PlayniteApi.Dialogs.GetCurrentAppWindow());
                 if (result == true)
                 {
+                    CloseAudioFiles();
                     string targetPath = dialog.FileName;
                     string SoundFilesDataPath = Path.Combine(GetPluginUserDataPath(), "Sound Files");
                     //just in case user deleted it
@@ -706,7 +707,6 @@ namespace PlayniteSounds
                             }
                         }
                     }
-                    CloseAudioFiles();
                     PlayniteApi.Dialogs.ShowMessage(Application.Current.FindResource("LOC_PLAYNITESOUNDS_ManagerLoadConfirm").ToString() + " " + Path.GetFileNameWithoutExtension(targetPath));
                 }
             }

--- a/PlayniteSounds.csproj
+++ b/PlayniteSounds.csproj
@@ -44,6 +44,8 @@
     <Reference Include="PresentationFramework" />
     <Reference Include="System" />
     <Reference Include="System.Core" />
+    <Reference Include="System.IO.Compression" />
+    <Reference Include="System.IO.Compression.FileSystem" />
     <Reference Include="System.Xaml" />
     <Reference Include="System.Xml.Linq" />
     <Reference Include="System.Data.DataSetExtensions" />
@@ -332,7 +334,4 @@
     </None>
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>xcopy $(TargetDir). "N:\Games\playnite\Extensions\Playnite.Sounds.WD" /y /s /e</PostBuildEvent>
-  </PropertyGroup>
 </Project>

--- a/PlayniteSoundsSettingsView.xaml
+++ b/PlayniteSoundsSettingsView.xaml
@@ -50,13 +50,35 @@
                 <Slider Name="VolumeSlider" Grid.Row="6" Grid.Column="1" Maximum="100" Value="{Binding MusicVolume}"  AutoToolTipPlacement="TopLeft" ValueChanged="Slider_ValueChanged" VerticalAlignment="Center"></Slider>
             </Grid>
         </GroupBox>
-        <GroupBox Name="GrpActions" Header="{DynamicResource LOC_PLAYNITESOUNDS_Actions}" Margin="0,5,0,0">
-            <StackPanel Orientation="Horizontal">
-                <Button Name="ButReloadAudio" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsReloadAudioFiles}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButReloadAudio_Click"/>
-                <Button Name="ButOpenSoundsFolder" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsOpenSoundsFolder}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenSoundsFolder_Click"/>
-                <Button Name="ButOpenMusicFolder" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsOpenMusicFolder}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenMusicFolder_Click"/>
-                <Button Name="ButOpenInfo" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsHelp}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenInfo_Click"/>
+      <GroupBox Name="GrpActions" Header="{DynamicResource LOC_PLAYNITESOUNDS_Actions}" Margin="0,5,0,0">
+        <StackPanel Orientation="Horizontal">
+          <Button Name="ButReloadAudio" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsReloadAudioFiles}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButReloadAudio_Click"/>
+          <Button Name="ButOpenSoundsFolder" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsOpenSoundsFolder}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenSoundsFolder_Click"/>
+          <Button Name="ButOpenMusicFolder" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsOpenMusicFolder}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenMusicFolder_Click"/>
+          <Button Name="ButOpenInfo" Content="{DynamicResource LOC_PLAYNITESOUNDS_ActionsHelp}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenInfo_Click"/>
+        </StackPanel>
+      </GroupBox>
+        <GroupBox Name="GrpManager" Header="{DynamicResource LOC_PLAYNITESOUNDS_Manager}" Margin="0,5,0,0">
+          <Grid>
+            <Grid.ColumnDefinitions>
+              <ColumnDefinition/>
+            </Grid.ColumnDefinitions>
+            <Grid.RowDefinitions>
+              <RowDefinition/>
+              <RowDefinition Height="10"/>
+              <RowDefinition/>
+            </Grid.RowDefinitions>
+            <StackPanel Grid.Row="0" Orientation="Horizontal">
+              <Button Name="ButLoadSounds" Content="{DynamicResource LOC_PLAYNITESOUNDS_ManagerLoad}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButLoadSounds_Click"/>
+              <Button Name="ButSaveSounds" Content="{DynamicResource LOC_PLAYNITESOUNDS_ManagerSave}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButSaveSounds_Click"/>
+              <Button Name="ButRemoveSounds" Content="{DynamicResource LOC_PLAYNITESOUNDS_ManagerRemove}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButRemoveSounds_Click"/>
             </StackPanel>
+            <Separator Grid.Row="1"/>
+            <StackPanel Grid.Row="2" Orientation="Horizontal">
+              <Button Name="ButImportSounds" Content="{DynamicResource LOC_PLAYNITESOUNDS_ManagerImport}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButImportSounds_Click"/>
+              <Button Name="ButOpenSoundManagerFolder" Content="{DynamicResource LOC_PLAYNITESOUNDS_ManagerOpenManagerFolder}" HorizontalAlignment="Left" Margin="2" VerticalAlignment="Center" Click="ButOpenSoundManagerFolder_Click"/>
+            </StackPanel>
+          </Grid>
         </GroupBox>
     </StackPanel>
 

--- a/PlayniteSoundsSettingsView.xaml.cs
+++ b/PlayniteSoundsSettingsView.xaml.cs
@@ -49,5 +49,30 @@ namespace PlayniteSounds
         {
             plugin.ResetMusicVolume();
         }
+
+        private void ButSaveSounds_Click(object sender, RoutedEventArgs e)
+        {
+            plugin.SaveSounds();
+        }
+
+        private void ButLoadSounds_Click(object sender, RoutedEventArgs e)
+        {
+            plugin.LoadSounds();
+        }
+
+        private void ButImportSounds_Click(object sender, RoutedEventArgs e)
+        {
+            plugin.ImportSounds();
+        }
+
+        private void ButRemoveSounds_Click(object sender, RoutedEventArgs e)
+        {
+            plugin.RemoveSounds();
+        }
+
+        private void ButOpenSoundManagerFolder_Click(object sender, RoutedEventArgs e)
+        {
+            plugin.OpenSoundManagerFolder();
+        }
     }
 }

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Thanks to the following people who have contributed with translations:
 ## Credits
 * Used Icon made by [Freepik](http://www.freepik.com/)
 * Original Localization file loader by [Lacro59](https://github.com/Lacro59)
+* Sound Manager by [dfirsht](https://github.com/dfirsht)
 
 ## Donations
 [![paypal](https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif)](https://paypal.me/joyrider3774)


### PR DESCRIPTION
Inspired by [ThemeModifer](https://github.com/Lacro59/playnite-thememodifier-plugin), this PR adds a full sound manager to allow users to easily import and manage sound packs.

This will encourage users to change their soundscape often and hopefully encourage them to create and share their own sound packs.

I created a demo of the additions here: https://www.youtube.com/watch?v=NL1c7puTPz8

Note that this is my first time working with extensions and .NET in general so let me know if I made any mistakes.